### PR TITLE
makefile: separete board build folder from MCU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ format:
 TARGETS	= \
 	stm32l4xx \
 	stm32h7xx \
-	stm32f7xx
+	stm32f7xx \
+	matek_H7_slim \
+	pixhawk4
 
 all:	$(TARGETS)
 
@@ -100,10 +102,10 @@ clean:
 # Board specific targets.
 #
 matek_H7_slim:
-	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM
+	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM BOARD_FILE_NAME=$@
 
 pixhawk4:
-	${MAKE} stm32f7xx BOARD=PIXHAWK4
+	${MAKE} stm32f7xx BOARD=PIXHAWK4 BOARD_FILE_NAME=$@
 
 #
 # Microcontroller specific targets.

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,11 @@
 # Build path
-export BUILD_DIR = build/$(TARGET_FILE_NAME)
+ifdef BOARD
+export BUILD_DIR = build/$(BOARD_FILE_NAME)/build
+else
+export BUILD_DIR = build/$(TARGET_FILE_NAME)/build
+endif
+
+export TARGET_DIR = $(BUILD_DIR)/..
 
 C_DEFS += \
 -DGIT_BRANCH=\"$(BRANCH)\" \
@@ -17,9 +23,10 @@ endif
 
 ifdef BOARD
 CFLAGS += -D$(BOARD)
-endif
-
+TARGET := $(TARGET)_$(BOARD_FILE_NAME)
+else
 TARGET := $(TARGET)_$(TARGET_FILE_NAME)
+endif
 
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
@@ -34,9 +41,9 @@ LDFLAGS_SIGNATURE = $(MCU) -specs=nano.specs -TLinker/$(LDSCRIPT)_SIGNATURE.ld $
 # default action: build all
 all: debug signed
 
-debug: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
+debug: $(TARGET_DIR)/$(TARGET).elf $(TARGET_DIR)/$(TARGET).hex $(TARGET_DIR)/$(TARGET).bin
 
-signed: $(BUILD_DIR)/$(TARGET)_signed.elf $(BUILD_DIR)/$(TARGET)_signed.bin
+signed: $(TARGET_DIR)/$(TARGET)_signed.elf $(TARGET_DIR)/$(TARGET)_signed.bin
 
 
 #######################################
@@ -55,22 +62,22 @@ $(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
 $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 	$(AS) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
+$(TARGET_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
 	$(SZ) $@
 	
-$(BUILD_DIR)/$(TARGET)_signed.elf: $(OBJECTS) Makefile
+$(TARGET_DIR)/$(TARGET)_signed.elf: $(OBJECTS) Makefile
 	$(CC) $(OBJECTS) $(LDFLAGS_SIGNATURE) -o $@
 	$(SZ) $@
 	
 
-$(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
+$(TARGET_DIR)/%.hex: $(TARGET_DIR)/%.elf | $(BUILD_DIR)
 	$(HEX) $< $@
 	
-$(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
+$(TARGET_DIR)/%.bin: $(TARGET_DIR)/%.elf | $(BUILD_DIR)
 	$(BIN) $< $@	
 	
-$(BUILD_DIR)/%_signed.bin: $(BUILD_DIR)/%_signed.elf | $(BUILD_DIR)
+$(TARGET_DIR)/%_signed.bin: $(TARGET_DIR)/%_signed.elf | $(BUILD_DIR)
 	$(BIN) $< $@
 	
 $(BUILD_DIR):


### PR DESCRIPTION
- Updated Makefile to separate MCU builds from board builds since they don't have the same config (different LED for blink or PIN bootloader button).
- Also elf, bin, and hex files are taken outside for easier access