### PR TITLE
Add support for NUCLEO-H755ZI-Q board

### DIFF
--- a/LedBlink/Inc/boards_config.h
+++ b/LedBlink/Inc/boards_config.h
@@ -35,30 +35,38 @@
 #ifndef BOOTLOADER_INC_BOARDS_CONFIG_H_
 #define BOOTLOADER_INC_BOARDS_CONFIG_H_
 
-/* LED configuration for board available on the market */
-
-#ifdef MATEK_H743_SLIM
-#define LED1_Pin GPIO_PIN_4  // Green
-#define LED1_GPIO_Port GPIOE
-#define LED2_Pin GPIO_PIN_3  // Blue
-#define LED2_GPIO_Port GPIOE
-#define LED_ON    GPIO_PIN_RESET
-#define LED_OFF   GPIO_PIN_SET
+#ifdef NUCLEO_H755ZI
+#define LED1_Pin            GPIO_PIN_0  // Green
+#define LED1_GPIO_Port      GPIOB
+#define LED2_Pin            GPIO_PIN_14  // Red
+#define LED2_GPIO_Port      GPIOB
+#define LED_ON              GPIO_PIN_RESET
+#define LED_OFF             GPIO_PIN_SET
+#define PWR_SUPPLY          PWR_DIRECT_SMPS_SUPPLY
+#elif MATEK_H743_SLIM
+#define LED1_Pin            GPIO_PIN_4  // Green
+#define LED1_GPIO_Port      GPIOE
+#define LED2_Pin            GPIO_PIN_3  // Blue
+#define LED2_GPIO_Port      GPIOE
+#define LED_ON              GPIO_PIN_RESET
+#define LED_OFF             GPIO_PIN_SET
+#define PWR_SUPPLY          PWR_LDO_SUPPLY
 #elif PIXHAWK4
-#define LED1_Pin GPIO_PIN_6     // Green
-#define LED1_GPIO_Port GPIOC
-#define LED2_Pin GPIO_PIN_7     // Blue
-#define LED2_GPIO_Port GPIOC
-#define LED_ON    GPIO_PIN_RESET
-#define LED_OFF   GPIO_PIN_SET
+#define LED1_Pin            GPIO_PIN_6     // Green
+#define LED1_GPIO_Port      GPIOC
+#define LED2_Pin            GPIO_PIN_7     // Blue
+#define LED2_GPIO_Port      GPIOC
+#define LED_ON              GPIO_PIN_RESET
+#define LED_OFF             GPIO_PIN_SET
+#define PWR_SUPPLY          PWR_LDO_SUPPLY
 #else
-#define LED1_Pin GPIO_PIN_13
-#define LED1_GPIO_Port GPIOC
-#define LED2_Pin GPIO_PIN_14
-#define LED2_GPIO_Port GPIOC
-#define LED_ON    GPIO_PIN_SET
-#define LED_OFF   GPIO_PIN_RESET
-
+#define LED1_Pin            GPIO_PIN_13
+#define LED1_GPIO_Port      GPIOC
+#define LED2_Pin            GPIO_PIN_14
+#define LED2_GPIO_Port      GPIOC
+#define LED_ON              GPIO_PIN_SET
+#define LED_OFF             GPIO_PIN_RESET
+#define PWR_SUPPLY          PWR_LDO_SUPPLY
 #endif
 
 

--- a/LedBlink/STM32/Src/system_clock.c
+++ b/LedBlink/STM32/Src/system_clock.c
@@ -90,7 +90,7 @@ SystemClock_Config(void) {
 
     /** Supply configuration update enable
     */
-    HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
+    HAL_PWREx_ConfigSupply(PWR_SUPPLY);
     /** Configure the main internal regulator output voltage
     */
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ clean:
 #
 # Board specific targets.
 #
+nucleo_h755zi:
+	${MAKE} stm32h7xx BOARD=NUCLEO_H755ZI BOARD_FILE_NAME=$@
+	
 matek_H7_slim:
 	${MAKE} stm32h7xx BOARD=MATEK_H743_SLIM BOARD_FILE_NAME=$@
 

--- a/Makefile.stm32h7xx
+++ b/Makefile.stm32h7xx
@@ -53,9 +53,19 @@ AS_DEFS =
 # C defines
 C_DEFS =  \
 -DUSE_HAL_DRIVER \
--DSTM32H7xx \
--DSTM32H750xx \
--DSTM32H743xx
+-DSTM32H7xx
+
+ifeq ($(BOARD), NUCLEO_H755ZI)
+  C_DEFS += \
+  -DCORE_CM7 \
+  -DSTM32H755xx
+else ifeq ($(BOARD), MATEK_H743_SLIM)
+  C_DEFS += \
+  -DSTM32H743xx
+else
+  C_DEFS += \
+  -DSTM32H750xx
+endif
 
 # AS includes
 AS_INCLUDES = 


### PR DESCRIPTION
IMLedBlink example for board NUCLEO-H755ZI-Q 
Paired with https://github.com/IMProject/IMBootloader/pull/34