### PR TITLE
STM32N6xx:  add support for running from external flash

### DIFF
--- a/LedBlink/STM32/Src/system_stm32n6xx.c
+++ b/LedBlink/STM32/Src/system_stm32n6xx.c
@@ -234,8 +234,11 @@ SystemInit(void) {
     RCC->APB4ENR2 &= ~(0x00000010UL);
 
     /* XSPI2 & XSPIM reset                                  */
-    RCC->AHB5RSTSR = RCC_AHB5RSTSR_XSPIMRSTS | RCC_AHB5RSTSR_XSPI2RSTS;
-    RCC->AHB5RSTCR = RCC_AHB5RSTCR_XSPIMRSTC | RCC_AHB5RSTCR_XSPI2RSTC;
+    /* The XSPI2 & XSPIM reset is intentionally skipped when running from external flash
+       to preserve the flash controller configuration. Uncommenting the following lines
+       may disrupt execution if code is running from external flash. */
+    // RCC->AHB5RSTSR = RCC_AHB5RSTSR_XSPIMRSTS | RCC_AHB5RSTSR_XSPI2RSTS;
+    // RCC->AHB5RSTCR = RCC_AHB5RSTCR_XSPIMRSTC | RCC_AHB5RSTCR_XSPI2RSTC;
 
 #if defined(USER_TZ_SAU_SETUP)
     /* SAU/IDAU, FPU and Interrupts secure/non-secure allocation settings */

--- a/Linker/STM32N6xx_EXT_FLASH.ld
+++ b/Linker/STM32N6xx_EXT_FLASH.ld
@@ -1,0 +1,211 @@
+/*
+******************************************************************************
+**
+** @file        : STM32N657XX_AXISRAM2_fsbl.ld
+**
+** @author      : GPM Application Team
+**
+** @brief       : Linker script for STM32N657XX Device from STM32N6 series
+**                      512 KBytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+******************************************************************************
+** @attention
+**
+** Copyright (c) 2023 STMicroelectronics.
+** All rights reserved.
+**
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
+**
+******************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(AXISRAM1) + LENGTH(AXISRAM1); /* end of "RAM" Ram type memory */
+_sstack = _estack - _Min_Stack_Size;
+
+_Min_Heap_Size = 0x200; /* required amount of heap */
+_Min_Stack_Size = 0x800; /* required amount of stack */
+
+/* Memories definition */
+MEMORY
+{
+  AXISRAM1    (xrw)    : ORIGIN = 0x34000000, LENGTH = 1024K
+  BL_FLAG_RAM (xrw)    : ORIGIN = 0x34100000, LENGTH = 64 /* Bootloader flag in RAM */
+  ROM         (xrw)    : ORIGIN = 0x70100400, LENGTH = 255K
+}
+
+/* Sections */
+SECTIONS
+{
+  .bootloader_flag_ram (NOLOAD): 
+  {
+    . = ALIGN(4);
+    KEEP(*(.bootloader_flag_ram))
+    . = ALIGN(4);
+  } >BL_FLAG_RAM
+  
+  /* The startup code into "RAM" Ram type memory */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >ROM
+
+  /* The program code and other data into "RAM" Ram type memory */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >ROM
+
+  /* Constant data into "RAM" Ram type memory */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >ROM
+
+  .ARM.extab   (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+   {
+    . = ALIGN(4);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } >ROM
+
+  .ARM (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+   {
+    . = ALIGN(4);
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+    . = ALIGN(4);
+  } >ROM
+
+  .preinit_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  .init_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  .fini_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  /* Used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections into "RAM" Ram type memory */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+
+  } >AXISRAM1 AT> ROM
+
+  .noncacheable :
+  {
+    . = ALIGN(8);
+    __snoncacheable = .;/* create symbol for start of section */
+    KEEP(*(.noncacheable))
+    . = ALIGN(8);
+    __enoncacheable = .;  /* create symbol for end of section */
+  } > AXISRAM1
+
+
+  .gnu.sgstubs :
+  {
+    . = ALIGN(4);
+    *(.gnu.sgstubs*)   /* Secure Gateway stubs */
+    . = ALIGN(4);
+  } >ROM
+  /* Uninitialized data section into "RAM" Ram type memory */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >AXISRAM1
+
+  /* User_heap_stack section, used to check that there is enough "RAM" Ram  type memory left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >AXISRAM1
+
+  /* Remove information from the compiler libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/Linker/STM32N6xx_EXT_FLASH_SIGNATURE.ld
+++ b/Linker/STM32N6xx_EXT_FLASH_SIGNATURE.ld
@@ -1,0 +1,217 @@
+/*
+******************************************************************************
+**
+** @file        : STM32N657XX_AXISRAM2_fsbl.ld
+**
+** @author      : GPM Application Team
+**
+** @brief       : Linker script for STM32N657XX Device from STM32N6 series
+**                      1024 KBytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+******************************************************************************
+** @attention
+**
+** Copyright (c) 2023 STMicroelectronics.
+** All rights reserved.
+**
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
+**
+******************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(AXISRAM1) + LENGTH(AXISRAM1); /* end of "RAM" Ram type memory */
+_sstack = _estack - _Min_Stack_Size;
+
+_Min_Heap_Size = 0x200; /* required amount of heap */
+_Min_Stack_Size = 0x800; /* required amount of stack */
+
+/* Memories definition */
+MEMORY
+{
+  AXISRAM1    (xrw)    : ORIGIN = 0x34000000, LENGTH = 1024K
+  BL_FLAG_RAM (xrw)    : ORIGIN = 0x34100000, LENGTH = 64 /* Bootloader flag in RAM */
+  SIGNATURE   (rx)     : ORIGIN = 0x701003C0, LENGTH = 64 /* Never written to the FLASH, it is for binary signature. */
+  ROM         (xrw)    : ORIGIN = 0x70100400, LENGTH = 255K
+}
+
+/* Sections */
+SECTIONS
+{
+  .fw_signature : ALIGN(4)
+  {
+    KEEP(*(.fw_signature))
+  } >SIGNATURE
+  
+  .bootloader_flag_ram (NOLOAD): 
+  {
+    . = ALIGN(4);
+    KEEP(*(.bootloader_flag_ram))
+    . = ALIGN(4);
+  } >BL_FLAG_RAM
+
+  /* The startup code into "RAM" Ram type memory */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >ROM
+
+  /* The program code and other data into "RAM" Ram type memory */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >ROM
+
+  /* Constant data into "RAM" Ram type memory */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >ROM
+
+  .ARM.extab   (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+   {
+    . = ALIGN(4);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(4);
+  } >ROM
+
+  .ARM (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+   {
+    . = ALIGN(4);
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+    . = ALIGN(4);
+  } >ROM
+
+  .preinit_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  .init_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  .fini_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    . = ALIGN(4);
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+    . = ALIGN(4);
+  } >ROM
+
+  /* Used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections into "RAM" Ram type memory */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+
+  } >AXISRAM1 AT> ROM
+
+  .noncacheable :
+  {
+    . = ALIGN(8);
+    __snoncacheable = .;/* create symbol for start of section */
+    KEEP(*(.noncacheable))
+    . = ALIGN(8);
+    __enoncacheable = .;  /* create symbol for end of section */
+  } > AXISRAM1
+
+
+  .gnu.sgstubs :
+  {
+    . = ALIGN(4);
+    *(.gnu.sgstubs*)   /* Secure Gateway stubs */
+    . = ALIGN(4);
+  } >ROM
+  /* Uninitialized data section into "RAM" Ram type memory */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >AXISRAM1
+
+  /* User_heap_stack section, used to check that there is enough "RAM" Ram  type memory left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >AXISRAM1
+
+  /* Remove information from the compiler libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ export USB=FS
 #
 TARGETS	= \
 	nucleo_h755zi \
+	nucleo_n657x0_q_ext \
+	nucleo_n657x0_q_ram \
 	matek_H7_slim \
 	pixhawk4 \
 	stm32l4xx \
@@ -115,6 +117,9 @@ pixhawk4:
 stm32h735g_dk:
 	${MAKE} stm32h7xx BOARD=STM32H735G_DK BOARD_FILE_NAME=$@
 	
+nucleo_n657x0_q_ext:
+	${MAKE} stm32n6xx_ext BOARD=NUCLEO_N657X0_Q BOARD_FILE_NAME=$@
+	
 nucleo_n657x0_q_ram:
 	${MAKE} stm32n6xx_ram BOARD=NUCLEO_N657X0_Q BOARD_FILE_NAME=$@
 
@@ -133,6 +138,9 @@ stm32h7xx_ext: $(MAKEFILE_LIST)
 
 stm32l4xx: $(MAKEFILE_LIST)
 	${MAKE} -f Makefile.stm32l4xx LDSCRIPT=STM32L4xx.ld FLASH=INTERNAL_FLASH MCU_FILE_NAME=$@
+	
+stm32n6xx_ext: $(MAKEFILE_LIST)
+	${MAKE} -f Makefile.stm32n6xx LDSCRIPT=STM32N6xx_EXT_FLASH.ld FLASH=EXTERNAL_FLASH MCU_FILE_NAME=$@
 	
 stm32n6xx_ram: $(MAKEFILE_LIST)
 	${MAKE} -f Makefile.stm32n6xx LDSCRIPT=STM32N6xx_RAM.ld FLASH=EXTERNAL_FLASH MCU_FILE_NAME=$@


### PR DESCRIPTION
This is an example of IMLedBlink running from external flash in memory-mapped mode.